### PR TITLE
Increment the bitpat search value

### DIFF
--- a/krb/lc_trie.hpp
+++ b/krb/lc_trie.hpp
@@ -403,6 +403,7 @@ void lc_trie<IPType, adrsize>::build_recursive
       bits = branch + newprefix - base[p].len;
       for(i = bitpat; i < bitpat + (1<<bits); ++i)
         build_recursive(tree, base, newprefix+branch, p, 1, adr+i, nextfree);
+      bitpat += (1 << bits) -1;
     } else
       build_recursive(tree, base, newprefix+branch, p, k, adr+bitpat, nextfree);
 


### PR DESCRIPTION
The bitpat value needs to be updated to skip the nodes that were just set. This can be validated by getting no hit for '164.255.0.0' with the following prefixes in the LC Trie and setting the root branching factor to 16.
```
0.0.0.0/4
16.0.0.0/4
40.0.0.0/5
64.0.0.0/3
96.0.0.0/4
112.0.0.0/4
128.0.0.0/3
160.0.0.0/6
164.0.0.0/6
168.0.0.0/5
176.0.0.0/5
184.0.0.0/5
192.0.0.0/3
232.0.0.0/8
233.0.0.0/8```